### PR TITLE
Fix hack path

### DIFF
--- a/genmocks.go
+++ b/genmocks.go
@@ -47,7 +47,7 @@ func findInterface(iface string, srcDir string) (path string, id string, err err
 		return "", "", fmt.Errorf("couldn't parse interface: %s", iface)
 	}
 
-	srcPath := filepath.Join(srcDir, "__go_impl__.go")
+	srcPath := filepath.Join(srcDir, "/hack/__go_impl__.go")
 
 	if slash := strings.LastIndex(iface, "/"); slash > -1 {
 		// package path provided


### PR DESCRIPTION
On ubuntu 18.04, this tool breaks because the proper path is not defined for a temporary hack file used to extract the import path of a given interface. This fix corrects the hack path so that it is able to find the correct path for a given interface.